### PR TITLE
Convert selects to use lua scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ cython_debug/
 .python-version
 
 env3.7/
+/lua_scripts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.0] - 2022-12-15
+
+### Added
+
+### Changed
+
+- Changed the `NESTED_MODEL_LIST_FIELD_PREFIX` to "___" and `NESTED_MODEL_TUPLE_FIELD_PREFIX` to "____"
+- Changed all queries (selects) to use lua scripts
+- Changed `Model.deserialize_partially` to receive data either as a dict or as a flattened list of key-values
+
+### Fixed
+
 ## [0.1.8] - 2022-12-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -167,6 +167,43 @@ Library.delete(ids=["The Grand Library"])
   pytest --benchmark-compare --benchmark-autosave
   ```
 
+- Or run to get benchmarks summary
+
+  ```shell
+  pytest test/test_benchmarks.py --benchmark-columns=mean,min,max --benchmark-name=short
+  ```
+
+## Benchmarks
+
+On an average PC ~16GB RAM, i7 Core
+
+```
+------------------------------------------------- benchmark: 20 tests -------------------------------------------------
+Name (time in us)                                              Mean                 Min                   Max          
+-----------------------------------------------------------------------------------------------------------------------
+benchmark_select_columns_for_one_id[redis_store-book1]     143.5316 (1.08)     117.4340 (1.0)        347.5900 (1.0)    
+benchmark_select_columns_for_one_id[redis_store-book3]     151.6032 (1.14)     117.6690 (1.00)       405.4620 (1.17)   
+benchmark_select_columns_for_one_id[redis_store-book0]     133.0856 (1.0)      117.8720 (1.00)       403.9400 (1.16)   
+benchmark_select_columns_for_one_id[redis_store-book2]     156.8152 (1.18)     118.7220 (1.01)       569.9800 (1.64)   
+benchmark_select_columns_for_some_items[redis_store]       138.0488 (1.04)     120.1550 (1.02)       350.7040 (1.01)   
+benchmark_delete[redis_store-Wuthering Heights]            199.9205 (1.50)     127.6990 (1.09)     1,092.2190 (3.14)   
+benchmark_bulk_delete[redis_store]                         178.4756 (1.34)     143.7480 (1.22)       647.6660 (1.86)   
+benchmark_select_all_for_one_id[redis_store-book1]         245.7787 (1.85)     195.2030 (1.66)       528.9250 (1.52)   
+benchmark_select_all_for_one_id[redis_store-book0]         239.1152 (1.80)     199.4360 (1.70)       767.2540 (2.21)   
+benchmark_select_all_for_one_id[redis_store-book3]         243.8724 (1.83)     200.8060 (1.71)       535.3640 (1.54)   
+benchmark_select_all_for_one_id[redis_store-book2]         256.1625 (1.92)     202.4630 (1.72)       701.3000 (2.02)   
+benchmark_update[redis_store-Wuthering Heights-data0]      329.1363 (2.47)     266.9700 (2.27)       742.1360 (2.14)   
+benchmark_select_some_items[redis_store]                   301.0471 (2.26)     268.9410 (2.29)       551.1060 (1.59)   
+benchmark_select_columns[redis_store]                      313.4356 (2.36)     281.4460 (2.40)       578.7730 (1.67)   
+benchmark_single_insert[redis_store-book2]                 348.5624 (2.62)     297.3610 (2.53)       580.8780 (1.67)   
+benchmark_single_insert[redis_store-book1]                 342.1879 (2.57)     297.5410 (2.53)       650.5420 (1.87)   
+benchmark_single_insert[redis_store-book0]                 366.4513 (2.75)     310.1640 (2.64)       660.5380 (1.90)   
+benchmark_single_insert[redis_store-book3]                 377.6208 (2.84)     327.5290 (2.79)       643.4090 (1.85)   
+benchmark_select_default[redis_store]                      486.6931 (3.66)     428.8810 (3.65)     1,181.9620 (3.40)   
+benchmark_bulk_insert[redis_store]                         897.7862 (6.75)     848.7410 (7.23)     1,188.5160 (3.42)   
+-----------------------------------------------------------------------------------------------------------------------
+```
+
 ## License
 
 Copyright (c) 2020 [Martin Ahindura](https://github.com/Tinitto) Licensed under the [MIT License](./LICENSE)

--- a/pydantic_redis/__init__.py
+++ b/pydantic_redis/__init__.py
@@ -4,4 +4,4 @@ from .config import RedisConfig
 from .model import Model
 from .store import Store
 
-__version__ = "0.1.8"
+__version__ = "0.2.0"

--- a/pydantic_redis/abstract.py
+++ b/pydantic_redis/abstract.py
@@ -4,6 +4,7 @@ from typing import Optional, Union, Any, Dict, List, Callable
 import orjson
 import redis
 from pydantic import BaseModel
+from redis.commands.core import Script
 
 from pydantic_redis.config import RedisConfig
 
@@ -17,6 +18,10 @@ class _AbstractStore(BaseModel):
     redis_config: RedisConfig
     redis_store: Optional[redis.Redis] = None
     life_span_in_seconds: Optional[int] = None
+    select_all_fields_for_all_ids_script: Optional[Script] = None
+    select_all_fields_for_some_ids_script: Optional[Script] = None
+    select_some_fields_for_all_ids_script: Optional[Script] = None
+    select_some_fields_for_some_ids_script: Optional[Script] = None
 
     class Config:
         arbitrary_types_allowed = True

--- a/pydantic_redis/abstract.py
+++ b/pydantic_redis/abstract.py
@@ -1,5 +1,5 @@
 """Module containing the main base classes"""
-from typing import Optional, Union, Any, Dict, List, Callable
+from typing import Optional, Union, Any, Dict, List, Callable, Tuple, Type
 
 import orjson
 import redis
@@ -35,28 +35,55 @@ class _AbstractModel(BaseModel):
 
     _store: _AbstractStore
     _primary_key_field: str
+    _nested_model_tuple_fields: Dict[str, Tuple[Any, ...]] = {}
+    _nested_model_list_fields: Dict[str, Type["_AbstractModel"]] = {}
+    _nested_model_fields: Dict[str, Type["_AbstractModel"]] = {}
+    _field_types: Dict[str, Any] = {}
+
+    class Config:
+        arbitrary_types_allowed = True
 
     @classmethod
     def serialize_partially(cls, data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         """Converts non primitive data types into str"""
-        return {
-            key: value
-            if isinstance(value, str)
-            else orjson.dumps(value, default=_default_json_dump)
-            for key, value in data.items()
-        }
+        return {key: _from_any_to_str_or_bytes(value) for key, value in data.items()}
 
     @classmethod
-    def deserialize_partially(cls, data: Optional[Dict[bytes, Any]]) -> Dict[str, Any]:
-        """Converts non primitive data types into str"""
-        return {
-            str(key, "utf-8")
-            if isinstance(key, bytes)
-            else key: value
-            if isinstance(value, str)
-            else orjson.loads(value)
-            for key, value in data.items()
-        }
+    def deserialize_partially(
+        cls, data: Union[List[Any], Dict[Any, Any]] = ()
+    ) -> Dict[str, Any]:
+        """
+        Converts str or bytes to their expected data types, given a list of properties got from the
+        list of lists got after calling EVAL on redis.
+
+        EVAL returns a List of Lists of key, values where the value for a given key is in the position
+        just after the key e.g. [["foo", "bar", "head", 9]] => [{"foo": "bar", "head": 9}]
+
+        Note: For backward compatibility, data can also be a dict.
+        """
+        if isinstance(data, dict):
+            # for backward compatibility
+            data = _from_dict_to_key_value_list(data)
+
+        parsed_dict = {}
+
+        for i in range(0, len(data), 2):
+            key = _from_bytes_to_str(data[i])
+            field_type = cls._field_types.get(key)
+            value = _from_str_or_bytes_to_any(value=data[i + 1], field_type=field_type)
+
+            if key in cls._nested_model_list_fields and value is not None:
+                value = cls.__deserialize_nested_model_list(field=key, value=value)
+
+            elif key in cls._nested_model_tuple_fields and value is not None:
+                value = cls.__deserialize_nested_model_tuple(field=key, value=value)
+
+            elif key in cls._nested_model_fields and value is not None:
+                value = cls.__deserialize_nested_model(field=key, value=value)
+
+            parsed_dict[key] = value
+
+        return parsed_dict
 
     @classmethod
     def get_primary_key_field(cls):
@@ -82,8 +109,59 @@ class _AbstractModel(BaseModel):
         """Should later allow AND, OR"""
         raise NotImplementedError("select should be implemented")
 
-    class Config:
-        arbitrary_types_allowed = True
+    @classmethod
+    def __deserialize_nested_model_list(
+        cls, field: str, value: List[Any]
+    ) -> List["_AbstractModel"]:
+        """Deserializes a list of key values for the given field returning a list of nested models"""
+        field_type = cls._nested_model_list_fields.get(field)
+        return [field_type(**field_type.deserialize_partially(item)) for item in value]
+
+    @classmethod
+    def __deserialize_nested_model_tuple(
+        cls, field: str, value: List[Any]
+    ) -> Tuple[Any, ...]:
+        """Deserializes a list of key values for the given field returning a tuple of nested models among others"""
+        field_types = cls._nested_model_tuple_fields.get(field, ())
+
+        items = []
+        for field_type, value in zip(field_types, value):
+            if issubclass(field_type, _AbstractModel) and value is not None:
+                value = field_type(**field_type.deserialize_partially(value))
+            items.append(value)
+
+        return tuple(items)
+
+    @classmethod
+    def __deserialize_nested_model(
+        cls, field: str, value: List[Any]
+    ) -> "_AbstractModel":
+        """Deserializes a list of key values for the given field returning the nested model"""
+        field_type = cls._nested_model_fields.get(field)
+        return field_type(**field_type.deserialize_partially(value))
+
+
+def _from_bytes_to_str(value: Union[str, bytes]) -> str:
+    """Converts bytes to str"""
+    if isinstance(value, bytes):
+        return str(value, "utf-8")
+    return value
+
+
+def _from_str_or_bytes_to_any(value: Any, field_type: Type) -> Any:
+    """Converts str or bytes to arbitrary data"""
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return orjson.loads(value)
+    elif isinstance(value, str) and field_type != str:
+        return orjson.loads(value)
+    return value
+
+
+def _from_any_to_str_or_bytes(value: Any) -> Union[str, bytes]:
+    """Converts arbitrary data into str or bytes"""
+    if isinstance(value, str):
+        return value
+    return orjson.dumps(value, default=_default_json_dump)
 
 
 def _default_json_dump(obj):
@@ -91,5 +169,17 @@ def _default_json_dump(obj):
     if hasattr(obj, "json") and isinstance(obj.json, Callable):
         return obj.json()
     elif isinstance(obj, set):
-        # Set does not exist in JSON. It's fine to use list instead, it becomes a Set when deserializing.
+        # Set does not exist in JSON.
+        # It's fine to use list instead, it becomes a Set when deserializing.
         return list(obj)
+
+
+def _from_dict_to_key_value_list(data: Dict[str, Any]) -> List[Any]:
+    """Converts dict to flattened list of key, values where the value after the key"""
+    parsed_list = []
+
+    for k, v in data.items():
+        parsed_list.append(k)
+        parsed_list.append(v)
+
+    return parsed_list

--- a/pydantic_redis/model.py
+++ b/pydantic_redis/model.py
@@ -342,7 +342,7 @@ class Model(_AbstractModel):
         if life_span is not None:
             pipeline.expire(table_index_key, time=life_span)
 
-        return key
+        return name
 
     @classmethod
     def __get_serializable_dict(

--- a/pydantic_redis/store.py
+++ b/pydantic_redis/store.py
@@ -7,6 +7,139 @@ from pydantic_redis.abstract import _AbstractStore
 from pydantic_redis.config import RedisConfig
 from pydantic_redis.model import Model
 
+SELECT_SOME_FIELDS_FOR_ALL_IDS_SCRIPT = """
+local filtered = {}
+local cursor = '0'
+local table_unpack = table.unpack or unpack
+local columns = {  }
+local nested_columns = {}
+local args_tracker = {}
+
+for i, k in ipairs(ARGV) do
+    if i > 1 then
+        if args_tracker[k] then
+            nested_columns[k] = true
+        else
+            table.insert(columns, k)
+            args_tracker[k] = true
+        end
+    end
+end
+
+repeat
+    local result = redis.call('SCAN', cursor, 'MATCH', ARGV[1])
+    for _, key in ipairs(result[2]) do
+        if redis.call('TYPE', key).ok == 'hash' then
+            local data = redis.call('HMGET', key, table_unpack(columns))
+            local parsed_data = {}
+
+            for i, v in ipairs(data) do
+                table.insert(parsed_data, columns[i])
+
+                if nested_columns[columns[i]] then
+                    v = redis.call('HGETALL', v)
+                end
+
+                table.insert(parsed_data, v)
+            end
+
+            table.insert(filtered, parsed_data)
+        end
+    end
+    cursor = result[1]
+until (cursor == '0')
+return filtered
+"""
+SELECT_ALL_FIELDS_FOR_ALL_IDS_SCRIPT = """
+local filtered = {}
+local cursor = '0'
+local nested_fields = {}
+
+for i, key in ipairs(ARGV) do
+    if i > 1 then
+        nested_fields[key] = true
+    end
+end
+
+repeat
+    local result = redis.call('SCAN', cursor, 'MATCH', ARGV[1])
+    for _, key in ipairs(result[2]) do
+        if redis.call('TYPE', key).ok == 'hash' then
+            local parent = redis.call('HGETALL', key)
+
+            for i, k in ipairs(parent) do
+                if nested_fields[k] then
+                    local nested = redis.call('HGETALL', parent[i + 1])
+                    parent[i + 1] = nested
+                end
+            end
+
+            table.insert(filtered, parent)
+        end
+    end
+    cursor = result[1]
+until (cursor == '0')
+return filtered
+"""
+SELECT_ALL_FIELDS_FOR_SOME_IDS_SCRIPT = """
+local result = {}
+local nested_fields = {}
+
+for _, key in ipairs(ARGV) do
+    nested_fields[key] = true
+end
+
+for _, key in ipairs(KEYS) do
+    local parent = redis.call('HGETALL', key)
+
+    for i, k in ipairs(parent) do
+        if nested_fields[k] then
+            local nested = redis.call('HGETALL', parent[i + 1])
+            parent[i + 1] = nested
+        end
+    end
+
+    table.insert(result, parent)
+end
+return result
+"""
+SELECT_SOME_FIELDS_FOR_SOME_IDS_SCRIPT = """
+local result = {}
+local table_unpack = table.unpack or unpack
+local columns = {  }
+local nested_columns = {}
+local args_tracker = {}
+
+for i, k in ipairs(ARGV) do
+    if args_tracker[k] then
+        nested_columns[k] = true
+    else
+        table.insert(columns, k)
+        args_tracker[k] = true
+    end
+end
+
+for _, key in ipairs(KEYS) do
+    local data = redis.call('HMGET', key, table_unpack(columns))
+    local parsed_data = {}
+
+    for i, v in ipairs(data) do
+        if v then
+            table.insert(parsed_data, columns[i])
+
+            if nested_columns[columns[i]] then
+                v = redis.call('HGETALL', v)
+            end
+
+            table.insert(parsed_data, v)
+        end
+    end
+
+    table.insert(result, parsed_data)
+end
+return result
+"""
+
 
 class Store(_AbstractStore):
     """
@@ -35,6 +168,20 @@ class Store(_AbstractStore):
             self.redis_config.redis_url,
             encoding=self.redis_config.encoding,
             decode_responses=True,
+        )
+
+        # register lua scripts
+        self.select_all_fields_for_all_ids_script = self.redis_store.register_script(
+            SELECT_ALL_FIELDS_FOR_ALL_IDS_SCRIPT
+        )
+        self.select_all_fields_for_some_ids_script = self.redis_store.register_script(
+            SELECT_ALL_FIELDS_FOR_SOME_IDS_SCRIPT
+        )
+        self.select_some_fields_for_all_ids_script = self.redis_store.register_script(
+            SELECT_SOME_FIELDS_FOR_ALL_IDS_SCRIPT
+        )
+        self.select_some_fields_for_some_ids_script = self.redis_store.register_script(
+            SELECT_SOME_FIELDS_FOR_SOME_IDS_SCRIPT
         )
 
     def register_model(self, model_class: type(Model)):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ README = (HERE / "README.md").read_text()
 # This call to setup() does all the work
 setup(
     name="pydantic-redis",
-    version="0.1.8",
+    version="0.2.0",
     description="This package provides a simple ORM for redis using pydantic-like models.",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## What was Done

- Changed all queries (selects) to use lua scripts. This was to optimize eager-loading to use only one network request as opposed to multiple.
- Changed `Model.deserialize_partially` to receive data either as a dict or as a flattened list of key-values. This was to handle responses returned from [Redis.EVALSHA](https://redis.io/commands/evalsha/)
- Changed the `NESTED_MODEL_LIST_FIELD_PREFIX` to "___" and `NESTED_MODEL_TUPLE_FIELD_PREFIX` to "____". This was to avoid weird regex bug in lua [string.gmatch](http://lua-users.org/wiki/StringLibraryTutorial) as '%' and others are special characters.