### PR TITLE
[fix] str | None type in from_str_or_bytes_to_any

### DIFF
--- a/pydantic_redis/_shared/utils.py
+++ b/pydantic_redis/_shared/utils.py
@@ -82,7 +82,11 @@ def from_str_or_bytes_to_any(value: Any, field_type: Type) -> Any:
     """
     if isinstance(value, (bytes, bytearray, memoryview)):
         return orjson.loads(value)
-    elif isinstance(value, str) and field_type != str:
+    elif (
+        isinstance(value, str)
+        and field_type != str
+        and (str not in typing_get_args(field_type))
+    ):
         return orjson.loads(value)
     return value
 


### PR DESCRIPTION
Incorrect processing from_str_or_bytes_to_any in case of field_type=str | None and value holding real string. Look for str in field_type, return value if such str is present.