### PR TITLE
Fix error with the reference docs not being rendered

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,1 +1,17 @@
 ::: pydantic_redis
+    handler: python
+    options:
+        show_root_heading: true
+        members: []
+            
+
+::: pydantic_redis.syncio
+    handler: python
+    options:
+        show_root_heading: true
+
+
+::: pydantic_redis.asyncio
+    handler: python
+    options:
+        show_root_heading: true

--- a/pydantic_redis/__init__.py
+++ b/pydantic_redis/__init__.py
@@ -15,6 +15,6 @@ above classes
 from pydantic_redis.syncio import Store, Model, RedisConfig
 import pydantic_redis.asyncio
 
-__all__ = [Store, RedisConfig, Model, asyncio]
+__all__ = ["Store", "RedisConfig", "Model", "asyncio"]
 
 __version__ = "0.5.0"

--- a/pydantic_redis/asyncio/__init__.py
+++ b/pydantic_redis/asyncio/__init__.py
@@ -31,4 +31,4 @@ from .model import Model
 from .store import Store
 from ..config import RedisConfig
 
-__all__ = [Model, Store, RedisConfig]
+__all__ = ["Model", "Store", "RedisConfig"]

--- a/pydantic_redis/syncio/__init__.py
+++ b/pydantic_redis/syncio/__init__.py
@@ -27,4 +27,4 @@ from .model import Model
 from .store import Store
 from ..config import RedisConfig
 
-__all__ = [Model, Store, RedisConfig]
+__all__ = ["Model", "Store", "RedisConfig"]


### PR DESCRIPTION
### Why

The reference docs were not showing up in the docs site
Fixes #32 

### What was Done

- Changed the "__all__" declarations in the subpackages to be a list of strings instead of classes and modules
- Added the "syncio" and the "asyncio" modules to the `reference.md` page explicitly
- Added the headings for each module in the `reference.md` page

### How to Test

- Clone the repo

```shell
git clone git@github.com:sopherapps/pydantic-redis.git
```

- Install dependencies

```shell
cd pydantic-redis
python -m venv env
source env/bin/activate
```

- Serve the mkdocs site

```shell
mkdocs serve
```

- Visit the [http://127.0.0.1:8000/pydantic-redis/reference](http://127.0.0.1:8000/pydantic-redis/reference) in your browser