### PR TITLE
Fix possibility of Passing Multiple Redis Instances to the Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+- [BREAKING CHANGE] Removed the 'redis_store' argument from the `Store` constructor
+- [BREAKING CHANGE] Made the 'redis_store' property of the `Store` readonly
+
+### Fixed
+
+- Fixed the rendering of the reference docs from the docstrings
+
 ## [0.5.0] - 2024-02-10
 
 ### Added

--- a/pydantic_redis/asyncio/store.py
+++ b/pydantic_redis/asyncio/store.py
@@ -30,7 +30,6 @@ class Store(AbstractStore):
             Model name
         name (str): the name of this Store
         redis_config (pydantic_redis.syncio.RedisConfig): the configuration for connecting to a redis database
-        redis_store (Optional[redis.Redis]): an Redis instance associated with this store (default: None)
         life_span_in_seconds (Optional[int]): the default time-to-live for the records inserted in this store
             (default: None)
     """

--- a/pydantic_redis/syncio/store.py
+++ b/pydantic_redis/syncio/store.py
@@ -30,7 +30,6 @@ class Store(AbstractStore):
             Model name
         name (str): the name of this Store
         redis_config (pydantic_redis.syncio.RedisConfig): the configuration for connecting to a redis database
-        redis_store (Optional[redis.Redis]): an Redis instance associated with this store (default: None)
         life_span_in_seconds (Optional[int]): the default time-to-live for the records inserted in this store
             (default: None)
     """


### PR DESCRIPTION
### Why

It turns out, as reported by @wasperen2 in issue #29, that it is possible to pass two Redis instances to the `Store` on initialization in `Store(redis_config=..., redis_store=...)`. Allowing this to happen can cause all sorts of unexpected results. Currently, the redis instance constructed from the "redis_config" argument overwrites the value passed via "redis_store".

This should close #29 if @wasperen2 confirms that mocking using redislite the way it was done in the `test/conftest.py` is sufficient for their need.

### What was Done

The expectation was to have only one way of initializing the redis instance, that is, via the "redis_config" argument. 

This pull request attempts to remove the ambiguity caused by the extra argument "redis_store" by removing it and changing the `Store.redis_store` property to a readonly property.