### PR TITLE
Bump to v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Added
+## [0.7.0] - 2024-07-20
 
-### Changed
+### Added
 
 - Added support for dictionaries of nested models
 - Added support for deeply nested models beyond level-1 deep including:
   - dictionaries of lists of ... of nested models
   - lists of tuples of lists .... of nested models
+
+### Changed
 
 ### Fixed
 

--- a/pydantic_redis/__init__.py
+++ b/pydantic_redis/__init__.py
@@ -17,4 +17,4 @@ import pydantic_redis.asyncio
 
 __all__ = ["Store", "RedisConfig", "Model", "asyncio"]
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ README = (HERE / "README.md").read_text()
 # This call to setup() does all the work
 setup(
     name="pydantic-redis",
-    version="0.6.0",
+    version="0.7.0",
     description="This package provides a simple ORM for redis using pydantic-like models.",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## [0.7.0] - 2024-07-20

### Added

- Added support for dictionaries of nested models
- Added support for deeply nested models beyond level-1 deep including:
  - dictionaries of lists of ... of nested models
  - lists of tuples of lists .... of nested models

### Changed

### Fixed

- Fixed `AttributeError: 'get_primary_key_field'` when None is passed to a field with an optional nested model